### PR TITLE
Added option for centering pix2vox meshes

### DIFF
--- a/addons/voxel_factory/Pix2Vox/dock_exporter.gd
+++ b/addons/voxel_factory/Pix2Vox/dock_exporter.gd
@@ -3,9 +3,11 @@ extends Control
 
 var fs = null
 var current_file = null
+var centered = false
 onready var preview = get_node("Panel/VBoxContainer/MarginContainer2/TextureRect")
 onready var openButton = get_node("Panel/VBoxContainer/MarginContainer/Button")
-onready var exportButton = get_node("Panel/VBoxContainer/MarginContainer3/Button")
+onready var exportButton = get_node("Panel/VBoxContainer/MarginContainer4/Button")
+onready var centerButton = get_node("Panel/VBoxContainer/MarginContainer3/HBoxContainer/OptionButton")
 onready var fileDialog = get_node("FileDialog")
 onready var exportDialog = get_node("SaveDialog")
 onready var voxelFactory = get_node("VoxelFactory")
@@ -16,7 +18,8 @@ func _on_OpenButton_Pressed():
 
 # C# call
 func exportMesh(dir):
-	var mesh = voxelFactory.create_mesh_from_image_file(current_file)
+	centered = centerButton.selected
+	var mesh = voxelFactory.create_mesh_from_image_file(current_file, centered)
 	print("saved at: " + dir)
 	for vox in voxelFactory.Voxels:
 		mesh.set_meta(str(vox), voxelFactory.Voxels[vox])
@@ -49,3 +52,5 @@ func _on_Button_pressed():
 		
 func _on_SaveDialog_file_selected(path):
 	exportMesh(path)
+
+

--- a/addons/voxel_factory/Pix2Vox/dock_exporter.tscn
+++ b/addons/voxel_factory/Pix2Vox/dock_exporter.tscn
@@ -6,6 +6,7 @@
 [node name="Pix2Vox" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_right = -675.0
 script = ExtResource( 1 )
 
 [node name="Panel" type="Panel" parent="."]
@@ -17,7 +18,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel/VBoxContainer"]
-margin_right = 1024.0
+margin_right = 285.0
 margin_bottom = 75.0
 rect_min_size = Vector2( 0, 75 )
 custom_constants/margin_right = 15
@@ -28,37 +29,70 @@ custom_constants/margin_bottom = 15
 [node name="Button" type="Button" parent="Panel/VBoxContainer/MarginContainer"]
 margin_left = 15.0
 margin_top = 15.0
-margin_right = 1009.0
+margin_right = 270.0
 margin_bottom = 60.0
 text = "Open file"
 
 [node name="MarginContainer2" type="MarginContainer" parent="Panel/VBoxContainer"]
 margin_top = 79.0
-margin_right = 1024.0
-margin_bottom = 521.0
+margin_right = 285.0
+margin_bottom = 407.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="TextureRect" type="TextureRect" parent="Panel/VBoxContainer/MarginContainer2"]
-margin_right = 1024.0
-margin_bottom = 442.0
+margin_right = 285.0
+margin_bottom = 328.0
 expand = true
 stretch_mode = 6
 
 [node name="MarginContainer3" type="MarginContainer" parent="Panel/VBoxContainer"]
-margin_top = 525.0
-margin_right = 1024.0
-margin_bottom = 600.0
+margin_top = 411.0
+margin_right = 285.0
+margin_bottom = 461.0
+rect_min_size = Vector2( 0, 50 )
+custom_constants/margin_right = 15
+custom_constants/margin_top = 15
+custom_constants/margin_left = 15
+custom_constants/margin_bottom = 15
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/VBoxContainer/MarginContainer3"]
+margin_left = 15.0
+margin_top = 15.0
+margin_right = 270.0
+margin_bottom = 35.0
+custom_constants/separation = 10
+alignment = 1
+
+[node name="Label" type="Label" parent="Panel/VBoxContainer/MarginContainer3/HBoxContainer"]
+margin_left = 45.0
+margin_top = 3.0
+margin_right = 103.0
+margin_bottom = 17.0
+text = "Centered"
+
+[node name="OptionButton" type="OptionButton" parent="Panel/VBoxContainer/MarginContainer3/HBoxContainer"]
+margin_left = 113.0
+margin_right = 210.0
+margin_bottom = 20.0
+text = "Disabled"
+items = [ "Disabled", null, false, 0, null, "XZ", null, false, 1, null, "XYZ", null, false, 2, null ]
+selected = 0
+
+[node name="MarginContainer4" type="MarginContainer" parent="Panel/VBoxContainer"]
+margin_top = 465.0
+margin_right = 285.0
+margin_bottom = 540.0
 rect_min_size = Vector2( 0, 75 )
 custom_constants/margin_right = 15
 custom_constants/margin_top = 15
 custom_constants/margin_left = 15
 custom_constants/margin_bottom = 15
 
-[node name="Button" type="Button" parent="Panel/VBoxContainer/MarginContainer3"]
+[node name="Button" type="Button" parent="Panel/VBoxContainer/MarginContainer4"]
 margin_left = 15.0
 margin_top = 15.0
-margin_right = 1009.0
+margin_right = 270.0
 margin_bottom = 60.0
 text = "Export"
 
@@ -89,8 +123,7 @@ current_path = "F:/Desktop/VoxShowcase/"
 
 [node name="VoxelFactory" type="Node" parent="."]
 script = ExtResource( 2 )
-
 [connection signal="pressed" from="Panel/VBoxContainer/MarginContainer/Button" to="." method="_on_OpenButton_Pressed"]
-[connection signal="pressed" from="Panel/VBoxContainer/MarginContainer3/Button" to="." method="_on_Button_pressed"]
+[connection signal="pressed" from="Panel/VBoxContainer/MarginContainer4/Button" to="." method="_on_Button_pressed"]
 [connection signal="file_selected" from="SaveDialog" to="." method="_on_SaveDialog_file_selected"]
 [connection signal="file_selected" from="FileDialog" to="." method="_on_FileDialog_file_selected"]

--- a/addons/voxel_factory/voxel_factory.gd
+++ b/addons/voxel_factory/voxel_factory.gd
@@ -37,7 +37,7 @@ func _ready():
 	# Making sure that vertex color are used
 	DefaultMaterial.vertex_color_use_as_albedo = true
 	DefaultMaterial.vertex_color_is_srgb = true
-	DefaultMaterial.flags_transparent = true
+	#DefaultMaterial.flags_transparent = true
 	
 # Adds a voxel to the dict.
 func add_voxel(position, color):
@@ -49,24 +49,30 @@ func clear_voxels():
 	Voxels.clear()
 
 # From image file.
-func create_mesh_from_image_file(path) -> Mesh:
+func create_mesh_from_image_file(path, centered) -> Mesh:
 	var image = Image.new()
 	image.load(path)
-	return create_mesh_from_image(image)
+	return create_mesh_from_image(image, centered)
 
 # From image data-type
-func create_mesh_from_image(image) -> Mesh:
+func create_mesh_from_image(image, centered) -> Mesh:
 	Voxels.clear()
 	var imageSize = image.get_size()
-	
+	var imageWidth = image.get_width()
+	var imageHeight = image.get_height()
+	var offset = Vector3()
 	# Image is upside down by default.
 	image.flip_y()
 	image.lock()
 	
+	if centered == 1: #if only xz centered
+		offset = Vector3(imageWidth/2, 0, VoxelSize/2)#set offset based off half the size of a voxel and the image size
+	elif centered == 2: #if xyz centered
+		offset = Vector3(imageWidth/2, imageHeight/2, VoxelSize/2)
 	# For each pixel add a voxel.
 	for x in imageSize.x:
 		for y in imageSize.y:
-			add_voxel(Vector3(x, y, 0), image.get_pixel(x, y))
+			add_voxel(Vector3(x, y, 0)-offset, image.get_pixel(x, y))
 	
 	image.unlock()
 	return create_mesh()


### PR DESCRIPTION
The meshes generated from pix2vox were previously offset, so I added in the possibility to center them with an xz option or an xyz option while leaving centering disabled an option as well. 

I also commented out the transparency default for materials as it isn't really needed and generates rendering/performance issues. 